### PR TITLE
Fix applewebview detection

### DIFF
--- a/src/WebXRUtils.js
+++ b/src/WebXRUtils.js
@@ -60,7 +60,7 @@ THREE.WebXRUtils = {
 
             function isAppleWebView () {
               return (
-                navigator.userAgent.indexOf('AppleWebKit') &&
+                navigator.userAgent.indexOf('AppleWebKit') !== -1 &&
                 navigator.userAgent.indexOf('Safari') === -1
               );
             }


### PR DESCRIPTION
three.xr.js would otherwise detect Firefox for Android as an AR capable browser.